### PR TITLE
Mark Hurricane as `folia-supported`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Download here: [Hurricane Download](https://download.geysermc.org/v2/projects/hu
 - Bamboo and dripstone collision (by setting them to no server-side collision)
 
 Supported Versions:
-- 1.14.x - 1.21.7
+- 1.14.x - 1.21.8

--- a/spigot/src/main/resources/plugin.yml
+++ b/spigot/src/main/resources/plugin.yml
@@ -3,4 +3,5 @@ version: ${version}
 main: org.geysermc.hurricane.Hurricane
 api-version: 1.13
 authors: [ GeyserMC ]
+folia-supported: true
 softdepend: [Geyser-Spigot, floodgate]


### PR DESCRIPTION
Hurricane works under Folia, and as such, should be marked so Folia will load it. (Also bumps the version in the README to 1.21.8)