### PR TITLE
Update Hurricane to use Geyser API 2.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Download here: [Hurricane Download](https://download.geysermc.org/v2/projects/hu
 - Bamboo and dripstone collision (by setting them to no server-side collision)
 
 Supported Versions:
-- 1.14.x - 1.21.8
+- 1.14.x - 1.21.11

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 configurate ="4.2.0-SNAPSHOT"
-geyser ="2.4.2-SNAPSHOT"
+geyser ="2.9.3-SNAPSHOT"
 floodgate ="2.2.3-SNAPSHOT"
 paper ="1.18.2-R0.1-SNAPSHOT"
 paperweight = "1.7.7"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Changelog can be found in the commits.