### PR TITLE
Add Minecraft 26.1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
-# Hurricane
+# Hurricane (GZ Fork)
+
+Fork of [Hurricane](https://github.com/GeyserMC/Hurricane) with Minecraft 26.1 support.
+
+## Changes from upstream
+
+- Fixed NMS version detection for modern Paper (unversioned CraftBukkit packages)
+- Added mojmap class name support (`BambooStalkBlock`, `Shapes`) for 26.1+
+- Fixed bamboo collision field lookup using mojmap field name `SHAPE_COLLISION`
+- Added `Shapes.box()` method fallback for mojmap servers
+
+## Original Description
+
 Various workarounds for Geyser players that modify the server in order to achieve their goal.
 
 Issues with each workaround are listed in the plugin's config. **Please take your time to read them as the workarounds in this plugin can be used for exploitative purposes.**
-
-Download here: [Hurricane Download](https://download.geysermc.org/v2/projects/hurricane/versions/latest/builds/latest/downloads/spigot)
 
 ## Fixes:
 - Bamboo and dripstone collision (by setting them to no server-side collision)
 
 Supported Versions:
-- 1.14.x - 1.21.8
+- 1.14.x - 26.1+

--- a/README.md
+++ b/README.md
@@ -1,19 +1,10 @@
-# Hurricane (GZ Fork)
-
-Fork of [Hurricane](https://github.com/GeyserMC/Hurricane) with Minecraft 26.1 support.
-
-## Changes from upstream
-
-- Fixed NMS version detection for modern Paper (unversioned CraftBukkit packages)
-- Added mojmap class name support (`BambooStalkBlock`, `Shapes`) for 26.1+
-- Fixed bamboo collision field lookup using mojmap field name `SHAPE_COLLISION`
-- Added `Shapes.box()` method fallback for mojmap servers
-
-## Original Description
+# Hurricane
 
 Various workarounds for Geyser players that modify the server in order to achieve their goal.
 
 Issues with each workaround are listed in the plugin's config. **Please take your time to read them as the workarounds in this plugin can be used for exploitative purposes.**
+
+Download here: [Hurricane Download](https://download.geysermc.org/v2/projects/hurricane/versions/latest/builds/latest/downloads/spigot)
 
 ## Fixes:
 - Bamboo and dripstone collision (by setting them to no server-side collision)

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Download here: [Hurricane Download](https://download.geysermc.org/v2/projects/hu
 - Bamboo and dripstone collision (by setting them to no server-side collision)
 
 Supported Versions:
-- 1.14.x - 26.1+
+- 1.14.x - 26.1

--- a/reflection/src/main/java/org/geysermc/hurricane/NMSReflection.java
+++ b/reflection/src/main/java/org/geysermc/hurricane/NMSReflection.java
@@ -11,7 +11,11 @@ public final class NMSReflection {
     public static boolean mojmap = true;
 
     public static String getVersion() {
-        return version == null ? version = Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3] : version;
+        if (version == null) {
+            String[] parts = Bukkit.getServer().getClass().getPackage().getName().split("\\.");
+            version = parts.length > 3 ? parts[3] : "";
+        }
+        return version;
     }
 
     /**
@@ -26,15 +30,32 @@ public final class NMSReflection {
     }
 
     public static Class<?> getNMSClass(String post1_16Prefix, String name) {
-        Class<?> newNMSClass = getMojmapNMSClass(post1_16Prefix + "." + name);
+        return getNMSClass(post1_16Prefix, name, name);
+    }
+
+    public static Class<?> getNMSClass(String post1_16Prefix, String name, String mojmapName) {
+        // Try mojmap name first (Paper 1.20.5+/26.1+)
+        Class<?> newNMSClass = getMojmapNMSClass(post1_16Prefix + "." + mojmapName);
         if (newNMSClass != null) {
             return newNMSClass;
         }
 
+        // Try spigot-repackaged name (Paper 1.17-1.20.4)
+        if (!mojmapName.equals(name)) {
+            newNMSClass = getMojmapNMSClass(post1_16Prefix + "." + name);
+            if (newNMSClass != null) {
+                return newNMSClass;
+            }
+        }
+
         // Else Mojmap/post-1.17 is not in effect
         mojmap = false;
+        String ver = getVersion();
+        if (ver.isEmpty()) {
+            return null;
+        }
         try {
-            return Class.forName("net.minecraft.server." + getVersion() + "." + name);
+            return Class.forName("net.minecraft.server." + ver + "." + name);
         } catch (ClassNotFoundException ex) {
             ex.printStackTrace();
             return null;

--- a/spigot/src/main/java/org/geysermc/hurricane/CollisionFix.java
+++ b/spigot/src/main/java/org/geysermc/hurricane/CollisionFix.java
@@ -33,12 +33,19 @@ public final class CollisionFix implements Listener {
 
         if (bambooEnabled) {
             try {
-                final Class<?> bambooBlockClass = NMSReflection.getNMSClass("world.level.block", "BlockBamboo");
+                final Class<?> bambooBlockClass = NMSReflection.getNMSClass("world.level.block", "BlockBamboo", "BambooStalkBlock");
                 final boolean newerThanOrEqualTo1170 = NMSReflection.mojmap;
                 // Codec field being first bumps all fields - as of 1.20.4
                 final boolean newerThanOrEqualTo1204 = Arrays.stream(bambooBlockClass.getFields()).anyMatch(field -> field.getType().getSimpleName().equals("MapCodec"));
                 final boolean newerThanOrEqualTo1215 = NMSReflection.getNMSClass("world.level.block", "LeafLitterBlock") != null;
-                final Field bambooBoundingBox = ReflectionAPI.getFieldAccessible(bambooBlockClass, newerThanOrEqualTo1215 ? "S" : newerThanOrEqualTo1204 ? "g" : newerThanOrEqualTo1170 ? "f" : "c"); // Bounding box for "no leaves", according to Yarn.
+                // On mojmap (26.1+) the field has its real name; on Spigot mappings it's obfuscated
+                String fieldName;
+                if (bambooBlockClass.getName().contains("BambooStalkBlock")) {
+                    fieldName = "SHAPE_COLLISION"; // mojmap name
+                } else {
+                    fieldName = newerThanOrEqualTo1215 ? "S" : newerThanOrEqualTo1204 ? "g" : newerThanOrEqualTo1170 ? "f" : "c";
+                }
+                final Field bambooBoundingBox = ReflectionAPI.getFieldAccessible(bambooBlockClass, fieldName);
                 applyNoBoundingBox(bambooBoundingBox);
                 plugin.getLogger().info("Bamboo collision hack enabled.");
             } catch (Exception e) {
@@ -137,11 +144,18 @@ public final class CollisionFix implements Listener {
             Method createVoxelShape;
             try {
                 // 1.18+ - obfuscated methods
-                createVoxelShape = ReflectionAPI.getMethod(NMSReflection.getNMSClass("world.phys.shapes", "VoxelShapes"), "b",
+                Class<?> shapesClass = NMSReflection.getNMSClass("world.phys.shapes", "VoxelShapes", "Shapes");
+                createVoxelShape = ReflectionAPI.getMethod(shapesClass, "b",
                         double.class, double.class, double.class, double.class, double.class, double.class);
             } catch (NoSuchMethodException e) {
-                createVoxelShape = ReflectionAPI.getMethod(NMSReflection.getNMSClass("world.phys.shapes", "VoxelShapes"), "create",
-                        double.class, double.class, double.class, double.class, double.class, double.class);
+                Class<?> shapesClass = NMSReflection.getNMSClass("world.phys.shapes", "VoxelShapes", "Shapes");
+                try {
+                    createVoxelShape = ReflectionAPI.getMethod(shapesClass, "box",
+                            double.class, double.class, double.class, double.class, double.class, double.class);
+                } catch (NoSuchMethodException e2) {
+                    createVoxelShape = ReflectionAPI.getMethod(shapesClass, "create",
+                            double.class, double.class, double.class, double.class, double.class, double.class);
+                }
             }
             Object boundingBox = ReflectionAPI.invokeMethod(createVoxelShape, x1, y1, z1, x2, y2, z2);
             ReflectionAPI.setFinalValue(field, boundingBox);


### PR DESCRIPTION
- Fix NMS version detection for modern Paper (unversioned CraftBukkit)
- Add mojmap class names: BambooStalkBlock, Shapes
- Fix bamboo collision field lookup (SHAPE_COLLISION)
- Add Shapes.box() method fallback for mojmap servers
- Update supported versions to include 26.1+